### PR TITLE
Add makefile with `install`, `uninstall`, `check-requirements` phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+SHELL := /bin/bash
+
+.PHONY: \
+	check-requirements
+
+help: ### Show available commands short description
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+check-requirements: ### Check if requirements are satisfied
+	@. ./bin/check.sh && \
+	check_requirements
+
+install: check-requirements ### Install [scryer-shen with raco](https://github.com/mthom/scryer-shen/issues/2#issuecomment-2106059943)
+	@. ./bin/install.sh && \
+	install
+
+uninstall: check-requirements ### Uninstall [scryer-shen with raco](https://github.com/mthom/scryer-shen/issues/2#issuecomment-2106059943)
+	@. ./bin/install.sh && \
+	uninstall

--- a/bin/check.sh
+++ b/bin/check.sh
@@ -3,22 +3,19 @@ set -Eeu
 
 # Test if requirements are satisfied
 function check_requirements {
-  if ! command -v raco >> /dev/null 2>&1 || \
-  ! command -v ./dist/bin/scryer-prolog >> /dev/null 2>&1
-  then
+    if ! command -v raco >>/dev/null 2>&1 ||
+        ! command -v ./dist/bin/scryer-prolog >>/dev/null 2>&1; then
 
-    if ! command -v ./dist/bin/scryer-prolog >> /dev/null 2>&1
-    then
-      print_utf8 '%s.%s' 'Please install [scryer-prolog](https://github.com/mthom/scryer-prolog/blob/42a0d686a5db241924490a5cca5c8b1d5bd0e5b0/README.md#installing-scryer-prolog) executable' $'\n'
+        if ! command -v ./dist/bin/scryer-prolog >>/dev/null 2>&1; then
+            printf '%s.%s' 'Please install [scryer-prolog](https://github.com/mthom/scryer-prolog/blob/42a0d686a5db241924490a5cca5c8b1d5bd0e5b0/README.md#installing-scryer-prolog) executable' $'\n'
+        fi
+
+        if ! command -v raco >>/dev/null 2>&1; then
+            printf '%s.%s' 'Please install [raco](https://download.racket-lang.org/)' $'\n'
+        fi
+
+        return 1
     fi
-
-    if ! command -v raco >> /dev/null 2>&1;
-    then
-      print_utf8 '%s.%s' 'Please install [raco](https://download.racket-lang.org/)' $'\n'
-    fi
-
-    return 1
-  fi
 }
 
 set +Eeu

--- a/bin/check.sh
+++ b/bin/check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -Eeu
+
+# Test if requirements are satisfied
+function check_requirements {
+  if ! command -v raco >> /dev/null 2>&1 || \
+  ! command -v ./dist/bin/scryer-prolog >> /dev/null 2>&1
+  then
+
+    if ! command -v ./dist/bin/scryer-prolog >> /dev/null 2>&1
+    then
+      print_utf8 '%s.%s' 'Please install [scryer-prolog](https://github.com/mthom/scryer-prolog/blob/42a0d686a5db241924490a5cca5c8b1d5bd0e5b0/README.md#installing-scryer-prolog) executable' $'\n'
+    fi
+
+    if ! command -v raco >> /dev/null 2>&1;
+    then
+      print_utf8 '%s.%s' 'Please install [raco](https://download.racket-lang.org/)' $'\n'
+    fi
+
+    return 1
+  fi
+}
+
+set +Eeu

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -Eeu
+
+# Install scryer-shen executable
+function install {
+  raco setup
+  ( cd ../ && raco pkg install ./scryer-shen )
+  raco exe --cs -o shen ++lib racket/lang/reader repl.rkt
+}
+
+# Uninstall scryer-shen executable
+function uninstall {
+  ( cd ../ && raco pkg remove scryer-shen )
+}
+
+set +Eeu


### PR DESCRIPTION
Fixes https://github.com/mthom/scryer-shen/issues/2 
for possible integration or reuse.

Cons: requires Makefile as dependency.
Pros: prevents omitting important bits from the documentation for the installation step.

---

_On missing scryer-prolog executable event_, output

```
Please install [scryer-prolog](https://github.com/mthom/scryer-prolog/blob/42a0d686a5db241924490a5cca5c8b1d5bd0e5b0/README.md#installing-scryer-prolog) executable.
```

_On missing raco executable event_, output

```
Please install [raco](https://download.racket-lang.org/).
```
