### PR TITLE
Enabling shen executable installation with make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ doc/
 **.rktd
 **.sxref
 
+install-rust-toolchain.sh
+
 dist/
 shen
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ doc/
 **.sxref
 
 dist/
+shen
 
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL := /bin/bash
 	check-requirements \
 	install \
 	uninstall
+	install-rust-toolchain \
 
 help: ### Show available commands short description
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -14,6 +15,11 @@ check-requirements: ### Check if requirements are satisfied
 
 install: check-requirements ### Install [scryer-shen with raco](https://github.com/mthom/scryer-shen/issues/2#issuecomment-2106059943)
 	@. ./bin/install.sh && \
+
+install-rust-toolchain: check-requirements ### Install [default rust toolchain](https://rustup.rs/)
+	@. ./bin/install.sh && \
+	install_rust_toolchain
+
 	install
 
 uninstall: check-requirements ### Uninstall [scryer-shen with raco](https://github.com/mthom/scryer-shen/issues/2#issuecomment-2106059943)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 SHELL := /bin/bash
 
 .PHONY: \
+	build-scryer-prolog \
 	check-requirements \
+	clone-scryer-prolog-repository \
+	clone-scryer-shen-repository \
+	ensure-scryer-prolog-availability \
+	ensure-scryer-shen-availability \
 	install \
-	uninstall
 	install-rust-toolchain \
+	uninstall \
 
 help: ### Show available commands short description
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -13,14 +18,30 @@ check-requirements: ### Check if requirements are satisfied
 	@. ./bin/check.sh && \
 	check_requirements
 
+clone-scryer-prolog-repository: ### Clone scryer-prolog repository
+	test -d scryer-prolog || ( cd dist && git clone https://github.com/mthom/scryer-prolog )
+
+clone-scryer-shen-repository: ### Clone scryer-shen repository
+	test -d scryer-shen || git clone https://github.com/mthom/scryer-shen
+
 install: check-requirements ### Install [scryer-shen with raco](https://github.com/mthom/scryer-shen/issues/2#issuecomment-2106059943)
 	@. ./bin/install.sh && \
+	install
 
 install-rust-toolchain: check-requirements ### Install [default rust toolchain](https://rustup.rs/)
 	@. ./bin/install.sh && \
 	install_rust_toolchain
 
-	install
+build-scryer-prolog: install-rust-toolchain clone-scryer-prolog-repository ### Build scryer-prolog executable
+	( cd dist/scryer-prolog && \
+	$$HOME/.cargo/bin/cargo build --release )
+
+ensure-scryer-prolog-executable-availability: build-scryer-prolog ### Ensure Scryer prolog availability in ./dist/bin
+	mkdir -p dist/bin && \
+	mv ./dist/scryer-prolog/target/release/scryer-prolog ./dist/bin
+
+ensure-scryer-shen-executable-availability: ensure-scryer-prolog-executable-availability ### Ensure Scryer shen availability in ./
+	make install
 
 uninstall: check-requirements ### Uninstall [scryer-shen with raco](https://github.com/mthom/scryer-shen/issues/2#issuecomment-2106059943)
 	@. ./bin/install.sh && \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 SHELL := /bin/bash
 
 .PHONY: \
-	check-requirements
+	check-requirements \
+	install \
+	uninstall
 
 help: ### Show available commands short description
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -37,9 +37,16 @@ those found in programming languages like Agda and Lean.
 scryer-shen can be run in the Racket REPL (for
 `#lang shen` modules) or compiled to an executable using
 
-```
-> raco setup
-> raco exe --cs -o shen ++lib racket/lang/reader repl.rkt
+```shell
+# Install [GNU Make](https://www.gnu.org/software/make/#download)
+# Install [racket](https://download.racket-lang.org/)
+# before 
+# - logging into a shell terminal, and
+# - executing the following commands
+# from cloned `scryer-shen` project root directory
+# before passing `ensure-scryer-shen-executable-availability` target to make binary
+# so that making `shen` executable is made available
+make ensure-scryer-shen-executable-availability
 ```
 
 The scryer-prolog executable must be copied to

--- a/bin/check.sh
+++ b/bin/check.sh
@@ -16,6 +16,8 @@ function check_requirements {
 
         return 1
     fi
+
+      printf '%s.%s' 'Requirements (`scryer-prolog`, `raco`) appear to be satisfied' $'\n'
 }
 
 set +Eeu

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -6,6 +6,12 @@ function install {
   raco setup
   ( cd ../ && raco pkg install ./scryer-shen )
   raco exe --cs -o shen ++lib racket/lang/reader repl.rkt
+
+
+# ⚠️ [`curl`](https://curl.se/download.html) is required from some unix-compatible host
+function install_rust_toolchain {
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o install-rust-toolchain.sh
+  sh -c '( chmod u+x ./install-rust-toolchain.sh && ./install-rust-toolchain.sh -y )'
 }
 
 # Uninstall scryer-shen executable

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,22 +1,42 @@
 #!/usr/bin/env bash
 set -Eeu
 
-# Install scryer-shen executable
+# Install `scryer-shen` executable
 function install {
-  raco setup
-  ( cd ../ && raco pkg install ./scryer-shen )
-  raco exe --cs -o shen ++lib racket/lang/reader repl.rkt
+  if [ -e shen ];
+  then
+    printf '%s.%s' 'shen executable exists already.' $'\n'
 
+    return 0
+  fi
 
-# ⚠️ [`curl`](https://curl.se/download.html) is required from some unix-compatible host
-function install_rust_toolchain {
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o install-rust-toolchain.sh
-  sh -c '( chmod u+x ./install-rust-toolchain.sh && ./install-rust-toolchain.sh -y )'
+  local raco_executable
+  raco_executable=$(which raco)
+
+  "${raco_executable}" setup --clean
+  "${raco_executable}" setup
+
+  ( cd ../ && \
+    "${raco_executable}" pkg install ./scryer-shen )
+
+  ( "${raco_executable}" exe --cs -o shen ++lib racket/lang/reader repl.rkt || \
+    "${raco_executable}" pkg show scryer-shen )
 }
 
-# Uninstall scryer-shen executable
+# ⚠️ Requires [`curl`](https://curl.se/download.html)
+function install_rust_toolchain {
+  curl \
+    --proto '=https' \
+    --tlsv1.2 \
+    -sSf https://sh.rustup.rs \
+    -o install-rust-toolchain.sh && \
+    sh -c '( chmod u+x ./install-rust-toolchain.sh && ./install-rust-toolchain.sh -y )'
+}
+
+# Uninstall `scryer-shen` executable
 function uninstall {
-  ( cd ../ && raco pkg remove scryer-shen )
+  ( cd ../ && \
+    raco pkg remove scryer-shen )
 }
 
 set +Eeu


### PR DESCRIPTION
Assuming GNU Make, git and Racket have been installed 
from some host machine,
this pull-request is about adding 
a `Make` phony target for 
 - cloning `scryer-prolog` project repository with git
 - cloning `scryer-shen` project repository with git
 - installing `cargo` with `rustup`
   (requires `curl`)
 - building `scryer-prolog` binary with `cargo build --release`
 - moving `scryer-prolog` to `dist/bin`
 - installing `shen` executable when `shen` executable does not exist yet
 - revising the documentation (`README`)

```shell
# not sure it is needed though since i never asked beforehand 😅
# it is ok to request changes or 
# to close it in a straightforward way
# since writing the intermediate target allowed me to learn 
# about raco CLI API
make ensure-scryer-shen-executable-availability
```

This pull-request could be seen as 
https://github.com/mthom/scryer-shen/pull/3 follow-up PR 